### PR TITLE
Kucoin 2.0 - market data only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ notify:
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: circleci/openjdk:8-jdk-browsers@sha256:2e432b2598edfc72e9146bddd387b5eb1fca6b18bea9eb70ff7a005645771c86
         environment:
           MAVEN_OPTS: -Xmx3200m
     working_directory: ~/orko

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ notify:
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk-browsers@sha256:2e432b2598edfc72e9146bddd387b5eb1fca6b18bea9eb70ff7a005645771c86
+      - image: circleci/openjdk:8-jdk-browsers@sha256:40ae64c13a503125a452cb5ffb5c01d14742c01d3676d77aa276fc6b956168be
         environment:
           MAVEN_OPTS: -Xmx3200m
     working_directory: ~/orko

--- a/orko-app/example-config.yml
+++ b/orko-app/example-config.yml
@@ -17,26 +17,26 @@ database:
 #   botToken: YOU
 #   chatId: REALLYWANTTHIS
 exchanges:
-  gdax-sandbox:
-    apiKey: 
-    secretKey: 
-    passphrase: 
   gdax:
     apiKey: 
     secretKey: 
     passphrase: 
+    sandbox: false # default
+    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
   binance:
     apiKey: 
     secretKey:
+    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
   kucoin:
     apiKey: 
     secretKey: 
-  cryptopia:
-    apiKey: 
-    secretKey: 
+    passphrase: 
+    sandbox: true # TODO switch to live after Kucoin 2.0 goes live
+    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
   bitfinex:
     apiKey: 
-    secretKey: 
+    secretKey:
+    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
 jerseyClient:
   timeout: 5000ms
   connectionTimeout: 5000ms

--- a/orko-app/example-config.yml
+++ b/orko-app/example-config.yml
@@ -26,17 +26,29 @@ exchanges:
   binance:
     apiKey: 
     secretKey:
-    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
+    loadRemoteData: true
   kucoin:
     apiKey: 
     secretKey: 
     passphrase: 
-    sandbox: true # TODO switch to live after Kucoin 2.0 goes live
-    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
+    sandbox: false
+    loadRemoteData: true
   bitfinex:
     apiKey: 
     secretKey:
-    loadRemoteData: true # default. Disable if the exchange goes down to avoid spamming it for metadata requests
+    loadRemoteData: true
+  bitmex:
+    apiKey: 
+    secretKey: 
+    loadRemoteData: true
+  kraken:
+    apiKey: 
+    secretKey: 
+    loadRemoteData: true
+  bittrex:
+    apiKey: 
+    secretKey: 
+    loadRemoteData: 
 jerseyClient:
   timeout: 5000ms
   connectionTimeout: 5000ms

--- a/orko-app/heroku-config.yml
+++ b/orko-app/heroku-config.yml
@@ -20,32 +20,38 @@ database:
   connectionString: ${JAWSDB_URL}?rewriteBatchedStatements=true&useJDBCCompliantTimezoneShift=true
   lockSeconds: ${LOCK_SECONDS:-45}
 exchanges:
-  gdax-sandbox:
-    apiKey: ${GDAX_SANDBOX_API_KEY:-}
-    secretKey: ${GDAX_SANDBOX_SECRET:-}
-    passphrase: ${GDAX_SANDBOX_PASSPHRASE:-}
   gdax:
     apiKey: ${GDAX_API_KEY:-}
     secretKey: ${GDAX_SECRET:-}
     passphrase: ${GDAX_PASSPHRASE:-}
+    sandbox: ${GDAX_SANDBOX:-false}
+    loadRemoteData: ${GDAX_REMOTE_META:-true}
   binance:
     apiKey: ${BINANCE_API_KEY:-}
     secretKey: ${BINANCE_SECRET:-}
+    loadRemoteData: ${BINANCE_REMOTE_META:-true}
   kucoin:
     apiKey: ${KUCOIN_API_KEY:-}
     secretKey: ${KUCOIN_SECRET:-}
+    passphrase: ${KUCOIN_PASSPHRASE:-}
+    sandbox: ${KUCOIN_SANDBOX:-true}
+    loadRemoteData: ${KUCOIN_REMOTE_META:-true}
   bitfinex:
     apiKey: ${BITFINEX_API_KEY:-}
     secretKey: ${BITFINEX_SECRET:-}
+    loadRemoteData: ${BITFINEX_REMOTE_META:-true}
   bitmex:
     apiKey: ${BITMEX_API_KEY:-}
     secretKey: ${BITMEX_SECRET:-}
+    loadRemoteData: ${BITMEX_REMOTE_META:-true}
+  kraken:
+    apiKey: ${KRAKEN_API_KEY:-}
+    secretKey: ${KRAKEN_SECRET:-}
+    loadRemoteData: ${KRAKEN_REMOTE_META:-true}
   bittrex:
     apiKey: ${BITTREX_API_KEY:-}
     secretKey: ${BITTREX_SECRET:-}
-  cryptopia:
-    apiKey: ${CRYPTOPIA_API_KEY:-}
-    secretKey: ${CRYPTOPIA_SECRET:-}
+    loadRemoteData: ${BITTREX_REMOTE_META:-true}
 server:
   type: simple
   rootPath: /api/

--- a/orko-app/heroku-config.yml
+++ b/orko-app/heroku-config.yml
@@ -34,7 +34,7 @@ exchanges:
     apiKey: ${KUCOIN_API_KEY:-}
     secretKey: ${KUCOIN_SECRET:-}
     passphrase: ${KUCOIN_PASSPHRASE:-}
-    sandbox: ${KUCOIN_SANDBOX:-true}
+    sandbox: ${KUCOIN_SANDBOX:-false}
     loadRemoteData: ${KUCOIN_REMOTE_META:-true}
   bitfinex:
     apiKey: ${BITFINEX_API_KEY:-}

--- a/orko-app/integration-test-config.yml
+++ b/orko-app/integration-test-config.yml
@@ -14,6 +14,27 @@ auth:
     expirationMinutes: 1440
 database:
   connectionString: h2:mem:test;DB_CLOSE_DELAY=-1;MVCC=TRUE;DEFAULT_LOCK_TIMEOUT=60000
+exchanges:
+  gdax-sandbox:
+    apiKey:
+    secretKey:
+    passphrase:
+  gdax:
+    apiKey:
+    secretKey:
+    passphrase:
+  binance:
+    apiKey:
+    secretKey:
+  kucoin:
+    apiKey:
+    secretKey:
+  cryptopia:
+    apiKey:
+    secretKey:
+  bitfinex:
+    apiKey:
+    secretKey:
 jerseyClient:
   timeout: 5000ms
   connectionTimeout: 5000ms

--- a/orko-app/integration-test-config.yml
+++ b/orko-app/integration-test-config.yml
@@ -18,9 +18,6 @@ jerseyClient:
   timeout: 5000ms
   connectionTimeout: 5000ms
   connectionRequestTimeout: 5000ms
-exchanges:
-  kucoin: 
-    sandbox: true
 server:
   type: simple
   rootPath: /api/

--- a/orko-app/integration-test-config.yml
+++ b/orko-app/integration-test-config.yml
@@ -14,27 +14,6 @@ auth:
     expirationMinutes: 1440
 database:
   connectionString: h2:mem:test;DB_CLOSE_DELAY=-1;MVCC=TRUE;DEFAULT_LOCK_TIMEOUT=60000
-exchanges:
-  gdax-sandbox:
-    apiKey:
-    secretKey:
-    passphrase:
-  gdax:
-    apiKey:
-    secretKey:
-    passphrase:
-  binance:
-    apiKey:
-    secretKey:
-  kucoin:
-    apiKey:
-    secretKey:
-  cryptopia:
-    apiKey:
-    secretKey:
-  bitfinex:
-    apiKey:
-    secretKey:
 jerseyClient:
   timeout: 5000ms
   connectionTimeout: 5000ms

--- a/orko-app/integration-test-config.yml
+++ b/orko-app/integration-test-config.yml
@@ -18,6 +18,9 @@ jerseyClient:
   timeout: 5000ms
   connectionTimeout: 5000ms
   connectionRequestTimeout: 5000ms
+exchanges:
+  kucoin: 
+    sandbox: true
 server:
   type: simple
   rootPath: /api/

--- a/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeAccessHealthCheck.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeAccessHealthCheck.java
@@ -45,7 +45,7 @@ class ExchangeAccessHealthCheck extends HealthCheck {
   protected Result check() throws Exception {
     ResultBuilder result = Result.builder().healthy();
 
-    exchangeResource.list().stream().filter(ex -> !Exchanges.GDAX_SANDBOX.equals(ex.getCode())).forEach(exchange -> {
+    exchangeResource.list().stream().forEach(exchange -> {
       try {
         Pair pair = Iterables.getFirst(exchangeResource.pairs(exchange.getCode()), null);
         if (pair == null) {

--- a/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeConfiguration.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeConfiguration.java
@@ -18,6 +18,8 @@
 
 package com.gruelbox.orko.exchange;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ExchangeConfiguration {
@@ -26,6 +28,8 @@ public class ExchangeConfiguration {
   private String secretKey;
   private String apiKey;
   private String passphrase;
+  private boolean sandbox;
+  private boolean loadRemoteData = true;
 
   @JsonProperty
   public String getUserName() {
@@ -48,6 +52,16 @@ public class ExchangeConfiguration {
   }
 
   @JsonProperty
+  public boolean isSandbox() {
+    return sandbox;
+  }
+
+  @JsonProperty
+  public boolean isLoadRemoteData() {
+    return loadRemoteData;
+  }
+
+  @JsonProperty
   public void setUserName(String userName) {
     this.userName = userName;
   }
@@ -65,5 +79,19 @@ public class ExchangeConfiguration {
   @JsonProperty
   public void setPassphrase(String passphrase) {
     this.passphrase = passphrase;
+  }
+
+  @JsonProperty
+  public void setSandbox(boolean sandbox) {
+    this.sandbox = sandbox;
+  }
+
+  @JsonProperty
+  public void setLoadRemoteData(boolean loadRemoteData) {
+    this.loadRemoteData = loadRemoteData;
+  }
+
+  boolean isAuthenticated() {
+    return StringUtils.isNotEmpty(apiKey);
   }
 }

--- a/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeResource.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeResource.java
@@ -40,12 +40,12 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.binance.service.BinanceCancelOrderParams;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderStatus;
@@ -55,7 +55,6 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.StopOrder;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
-import org.knowm.xchange.kucoin.service.KucoinCancelOrderParams;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.DefaultCancelOrderParamId;
@@ -461,15 +460,14 @@ public class ExchangeResource implements WebResource {
   public Response cancelOrder(@PathParam("exchange") String exchange,
                               @PathParam("counter") String counter,
                               @PathParam("base") String base,
-                              @PathParam("id") String id,
-                              @QueryParam("orderType") org.knowm.xchange.dto.Order.OrderType orderType) throws IOException {
+                              @PathParam("id") String id) throws IOException {
     try {
-      // KucoinCancelOrderParams is the superset - pair, id and order type. Should work with pretty much any exchange,
+      // BinanceCancelOrderParams is the superset - pair and id. Should work with pretty much any exchange,
       // except Bitmex
       // TODO PR to fix bitmex
       CancelOrderParams cancelOrderParams = exchange.equals(Exchanges.BITMEX)
           ? new DefaultCancelOrderParamId(id)
-          : new KucoinCancelOrderParams(new CurrencyPair(base, counter), id, orderType);
+          : new BinanceCancelOrderParams(new CurrencyPair(base, counter), id);
       Date now = new Date();
       if (!tradeServiceFactory.getForExchange(exchange).cancelOrder(cancelOrderParams)) {
         throw new IllegalStateException("Order could not be cancelled");

--- a/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeService.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeService.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 
 import com.google.inject.ImplementedBy;
@@ -34,8 +33,6 @@ public interface ExchangeService {
   Collection<String> getExchanges();
 
   Exchange get(String name);
-
-  Ticker fetchTicker(TickerSpec ex);
 
   boolean isAuthenticated(String name);
 

--- a/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeServiceImpl.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/exchange/ExchangeServiceImpl.java
@@ -18,7 +18,6 @@
 
 package com.gruelbox.orko.exchange;
 
-import static com.gruelbox.orko.exchange.Exchanges.GDAX_SANDBOX;
 import static info.bitrich.xchangestream.service.ConnectableService.BEFORE_CONNECTION_HANDLER;
 import static java.util.stream.Stream.concat;
 
@@ -36,7 +35,6 @@ import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.meta.RateLimit;
@@ -54,7 +52,6 @@ import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.RateLimiter;
 import com.gruelbox.orko.OrkoConfiguration;
 import com.gruelbox.orko.spi.TickerSpec;
-import com.gruelbox.orko.util.CheckedExceptions;
 
 import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 
@@ -65,6 +62,7 @@ import info.bitrich.xchangestream.core.StreamingExchangeFactory;
 @VisibleForTesting
 public class ExchangeServiceImpl implements ExchangeService {
 
+  private static final ExchangeConfiguration VANILLA_CONFIG = new ExchangeConfiguration();
   private static final RateLimit DEFAULT_RATE = new RateLimit(1, 3, TimeUnit.SECONDS);
   private static final RateLimit[] NO_LIMITS = new RateLimit[0];
   private static final Duration THROTTLE_DURATION = Duration.ofMinutes(2);
@@ -77,17 +75,19 @@ public class ExchangeServiceImpl implements ExchangeService {
     @Override
     public Exchange load(String name) throws Exception {
       final ExchangeConfiguration exchangeConfiguration = configuration.getExchanges() == null
-        ? null
-        : configuration.getExchanges().get(name);
-      if (exchangeConfiguration == null || StringUtils.isEmpty(exchangeConfiguration.getApiKey()))
-        return publicApi(name);
-      return privateApi(name, exchangeConfiguration);
+        ? VANILLA_CONFIG
+        : MoreObjects.firstNonNull(configuration.getExchanges().get(name), VANILLA_CONFIG);
+      if (exchangeConfiguration.isAuthenticated()) {
+        return privateApi(name, exchangeConfiguration);
+      } else {
+        return publicApi(name, exchangeConfiguration);
+      }
     }
 
-    private Exchange publicApi(String name) {
+    private Exchange publicApi(String name, ExchangeConfiguration exchangeConfiguration) {
       try {
         LOGGER.debug("No API connection details.  Connecting to public API: {}", name);
-        final ExchangeSpecification exSpec = createExchangeSpecification(name);
+        final ExchangeSpecification exSpec = createExchangeSpecification(name, exchangeConfiguration);
         return createExchange(exSpec);
       } catch (InstantiationException | IllegalAccessException e) {
         throw new IllegalArgumentException("Failed to connect to exchange [" + name + "]");
@@ -96,17 +96,15 @@ public class ExchangeServiceImpl implements ExchangeService {
 
     private Exchange privateApi(String name, final ExchangeConfiguration exchangeConfiguration) {
       try {
-
         LOGGER.debug("Connecting to private API: {}", name);
-        final ExchangeSpecification exSpec = createExchangeSpecification(name);
-        if (name.equalsIgnoreCase(Exchanges.GDAX_SANDBOX) || name.equalsIgnoreCase(Exchanges.GDAX)) {
+        final ExchangeSpecification exSpec = createExchangeSpecification(name, exchangeConfiguration);
+        if (name.equalsIgnoreCase(Exchanges.KUCOIN) || name.equalsIgnoreCase(Exchanges.GDAX)) {
           exSpec.setExchangeSpecificParametersItem("passphrase", exchangeConfiguration.getPassphrase());
         }
         exSpec.setUserName(exchangeConfiguration.getUserName());
         exSpec.setApiKey(exchangeConfiguration.getApiKey());
         exSpec.setSecretKey(exchangeConfiguration.getSecretKey());
         return createExchange(exSpec);
-
       } catch (InstantiationException | IllegalAccessException e) {
         throw new IllegalArgumentException("Failed to connect to exchange [" + name + "]");
       }
@@ -120,11 +118,13 @@ public class ExchangeServiceImpl implements ExchangeService {
       }
     }
 
-    private ExchangeSpecification createExchangeSpecification(String exchangeName) throws InstantiationException, IllegalAccessException {
+    private ExchangeSpecification createExchangeSpecification(String exchangeName, ExchangeConfiguration exchangeConfiguration) throws InstantiationException, IllegalAccessException {
       final ExchangeSpecification exSpec = Exchanges.friendlyNameToClass(exchangeName).newInstance().getDefaultExchangeSpecification();
-      if (exchangeName.equalsIgnoreCase(GDAX_SANDBOX)) {
+      if (exchangeConfiguration.isSandbox()) {
+        LOGGER.info("Using {} sandbox", exchangeName);
         exSpec.setExchangeSpecificParametersItem("Use_Sandbox", true);
       }
+      exSpec.setShouldLoadRemoteMetaData(exchangeConfiguration.isLoadRemoteData());
       RateLimiter rateLimiter = RateLimiter.create(0.25); // TODO make this exchange specific
       exSpec.setExchangeSpecificParametersItem(
         BEFORE_CONNECTION_HANDLER,
@@ -181,23 +181,13 @@ public class ExchangeServiceImpl implements ExchangeService {
                   .transform(s -> s.replace("Exchange", ""))
                   .transform(String::toLowerCase)
                   .transform(s -> s.equals("coinbasepro") ? "gdax" : s)
-                  .filter(s -> !s.equals(Exchanges.KUCOIN)) // TODO temporarily disabled while 2.0 support is added
         )
-        .add(Exchanges.GDAX_SANDBOX)
         .build();
   }
 
   @Override
   public Exchange get(String name) {
     return exchanges.getUnchecked(name);
-  }
-
-  @Override
-  public Ticker fetchTicker(TickerSpec ex) {
-    return CheckedExceptions.callUnchecked(() ->
-      get(ex.exchange())
-      .getMarketDataService()
-      .getTicker(ex.currencyPair()));
   }
 
   @Override

--- a/orko-common/src/main/java/com/gruelbox/orko/exchange/Exchanges.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/exchange/Exchanges.java
@@ -41,7 +41,6 @@ public final class Exchanges {
 
   public static final String BINANCE = "binance";
   public static final String GDAX = "gdax";
-  public static final String GDAX_SANDBOX = "gdax-sandbox";
   public static final String KUCOIN = "kucoin";
   public static final String BITTREX = "bittrex";
   public static final String BITFINEX = "bitfinex";
@@ -70,7 +69,7 @@ public final class Exchanges {
    */
   public static Class<? extends Exchange> friendlyNameToClass(String friendlyName) {
 
-    if (friendlyName.equals(GDAX) || friendlyName.equals(GDAX_SANDBOX))
+    if (friendlyName.equals(GDAX))
       return CoinbaseProStreamingExchange.class;
 
     Optional<Class<? extends StreamingExchange>> streamingResult = STREAMING_EXCHANGE_TYPES.get()
@@ -100,8 +99,6 @@ public final class Exchanges {
     switch(exchange) {
       case GDAX:
         return "Coinbase Pro";
-      case GDAX_SANDBOX:
-        return "Coinbase Pro (Sandbox)";
       case BITMEX:
       case BITTREX:
       case KRAKEN:
@@ -125,7 +122,6 @@ public final class Exchanges {
       case BINANCE : return "https://www.binance.com/?ref=11396297";
       case BITMEX : return "https://www.bitmex.com/register/vQIGWT";
       case GDAX : return "https://pro.coinbase.com";
-      case GDAX_SANDBOX  : return "https://public.sandbox.pro.coinbase.com/";
       case KUCOIN : return "https://www.kucoin.com/#/?r=E649ku";
       case BITTREX : return "https://bittrex.com/";
       case BITFINEX : return "https://www.bitfinex.com/";

--- a/orko-common/src/main/java/com/gruelbox/orko/marketdata/MarketDataSubscriptionManager.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/marketdata/MarketDataSubscriptionManager.java
@@ -70,6 +70,7 @@ import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
+import org.knowm.xchange.exceptions.ExchangeSecurityException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.account.AccountService;
@@ -114,7 +115,6 @@ import com.gruelbox.orko.util.SafelyDispose;
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.ProductSubscription.ProductSubscriptionBuilder;
 import info.bitrich.xchangestream.core.StreamingExchange;
-import info.bitrich.xchangestream.service.exception.NotConnectedException;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
@@ -603,7 +603,7 @@ public class MarketDataSubscriptionManager extends AbstractExecutionThreadServic
       subscriptions.stream().filter(s -> !s.type().equals(BALANCE)).forEach(sub -> {
         try {
           disposables.add(connectSubscription(sub));
-        } catch (NotConnectedException | NotYetImplementedForExchangeException | NotAvailableFromExchangeException e) {
+        } catch (ExchangeSecurityException | NotYetImplementedForExchangeException | NotAvailableFromExchangeException e) {
           remainder.add(sub);
           connected.remove(sub);
         }
@@ -622,7 +622,7 @@ public class MarketDataSubscriptionManager extends AbstractExecutionThreadServic
                 .subscribe(balanceOut::emit, e -> LOGGER.error("Error in balance for " + exchangeName + "/" + currency, e))
             )
           );
-      } catch (NotYetImplementedForExchangeException | NotAvailableFromExchangeException | NotConnectedException e) {
+      } catch (ExchangeSecurityException | NotYetImplementedForExchangeException | NotAvailableFromExchangeException e) {
         subscriptions.stream()
           .filter(s -> s.type().equals(BALANCE))
           .forEach(s -> {

--- a/orko-common/src/main/java/com/gruelbox/orko/marketdata/MarketDataSubscriptionManager.java
+++ b/orko-common/src/main/java/com/gruelbox/orko/marketdata/MarketDataSubscriptionManager.java
@@ -806,7 +806,7 @@ public class MarketDataSubscriptionManager extends AbstractExecutionThreadServic
       OpenOrders fetched = tradeService.getOpenOrders(openOrdersParams);
 
       // TODO GDAX PR required
-      if (subscription.spec().exchange().equals(Exchanges.GDAX) || subscription.spec().exchange().equals(Exchanges.GDAX_SANDBOX)) {
+      if (subscription.spec().exchange().equals(Exchanges.GDAX)) {
         ImmutableList<LimitOrder> filteredOpen = FluentIterable.from(fetched.getOpenOrders()).filter(openOrdersParams::accept).toList();
         ImmutableList<? extends Order> filteredHidden = FluentIterable.from(fetched.getHiddenOrders()).toList();
         fetched = new OpenOrders(filteredOpen, (List<Order>) filteredHidden);
@@ -883,7 +883,7 @@ public class MarketDataSubscriptionManager extends AbstractExecutionThreadServic
       TradeHistoryParams params;
 
       // TODO fix with pull requests
-      if (subscription.spec().exchange().equals(Exchanges.BITMEX) || subscription.spec().exchange().equals(Exchanges.GDAX) || subscription.spec().exchange().equals(Exchanges.GDAX_SANDBOX)) {
+      if (subscription.spec().exchange().equals(Exchanges.BITMEX) || subscription.spec().exchange().equals(Exchanges.GDAX)) {
         params = new TradeHistoryParamCurrencyPair() {
 
           private CurrencyPair pair;

--- a/orko-common/src/test/java/com/gruelbox/orko/exchange/TestExchangeService.java
+++ b/orko-common/src/test/java/com/gruelbox/orko/exchange/TestExchangeService.java
@@ -18,60 +18,99 @@
 
 package com.gruelbox.orko.exchange;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import static com.gruelbox.orko.exchange.Exchanges.BINANCE;
+import static com.gruelbox.orko.exchange.Exchanges.BITFINEX;
+import static com.gruelbox.orko.exchange.Exchanges.BITMEX;
+import static com.gruelbox.orko.exchange.Exchanges.BITTREX;
+import static com.gruelbox.orko.exchange.Exchanges.GDAX;
+import static com.gruelbox.orko.exchange.Exchanges.KRAKEN;
+import static com.gruelbox.orko.exchange.Exchanges.KUCOIN;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+import org.knowm.xchange.kucoin.KucoinExchange;
+
+import com.google.common.collect.ImmutableMap;
 import com.gruelbox.orko.OrkoConfiguration;
+
+import info.bitrich.xchangestream.coinbasepro.CoinbaseProStreamingExchange;
 
 public class TestExchangeService {
 
-  private ExchangeServiceImpl exchangeService;
-
-  @Before
-  public void setup() {
-    exchangeService = new ExchangeServiceImpl(new OrkoConfiguration());
-  }
-
   @Test
   public void testGdax() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.GDAX));
+    ExchangeServiceImpl exchangeService = vanilla(GDAX);
+    assertTrue(exchangeService.getExchanges().contains(GDAX));
   }
 
   @Test
   public void testGdaxSandbox() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.GDAX_SANDBOX));
+    OrkoConfiguration config = baseConfig(GDAX);
+    config.getExchanges().get(GDAX).setSandbox(true);
+    ExchangeServiceImpl exchangeService = of(config);
+    assertTrue(exchangeService.getExchanges().contains(GDAX));
+    assertTrue(exchangeService.get(GDAX) instanceof CoinbaseProStreamingExchange);
   }
 
   @Test
   public void testBinance() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.BINANCE));
+    ExchangeServiceImpl exchangeService = vanilla(BINANCE);
+    assertTrue(exchangeService.getExchanges().contains(BINANCE));
   }
 
   @Test
   public void testBitfinex() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.BITFINEX));
+    ExchangeServiceImpl exchangeService = vanilla(BITFINEX);
+    assertTrue(exchangeService.getExchanges().contains(BITFINEX));
   }
 
   @Test
   public void testBittrex() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.BITTREX));
+    ExchangeServiceImpl exchangeService = vanilla(BITTREX);
+    assertTrue(exchangeService.getExchanges().contains(BITTREX));
   }
 
   @Test
   public void testBitmex() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.BITMEX));
+    ExchangeServiceImpl exchangeService = vanilla(BITMEX);
+    assertTrue(exchangeService.getExchanges().contains(BITMEX));
   }
 
   @Test
   public void testKraken() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.KRAKEN));
+    ExchangeServiceImpl exchangeService = vanilla(KRAKEN);
+    assertTrue(exchangeService.getExchanges().contains(KRAKEN));
   }
 
   @Test
-  @Ignore // TODO add this back when 2.0 is working
-  public void testKucoin() {
-    Assert.assertTrue(exchangeService.getExchanges().contains(Exchanges.KUCOIN));
+  public void testKucoinVanilla() {
+    ExchangeServiceImpl exchangeService = vanilla(KUCOIN);
+    assertTrue(exchangeService.getExchanges().contains(KUCOIN));
+    assertTrue(exchangeService.get(KUCOIN) instanceof KucoinExchange);
+  }
+
+  @Test
+  public void testKucoinSandbox() {
+    OrkoConfiguration config = baseConfig(KUCOIN);
+    config.getExchanges().get(KUCOIN).setSandbox(true);
+    ExchangeServiceImpl exchangeService = of(config);
+    assertTrue(exchangeService.getExchanges().contains(KUCOIN));
+    assertTrue(exchangeService.get(KUCOIN) instanceof KucoinExchange);
+  }
+
+  private OrkoConfiguration baseConfig(String exchange) {
+    OrkoConfiguration orkoConfiguration = new OrkoConfiguration();
+    orkoConfiguration.setExchanges(ImmutableMap.of(exchange, new ExchangeConfiguration()));
+    orkoConfiguration.getExchanges().get(exchange).setLoadRemoteData(false);
+    return orkoConfiguration;
+  }
+
+  private ExchangeServiceImpl vanilla(String exchange) {
+    return of(baseConfig(exchange));
+  }
+
+  private ExchangeServiceImpl of(OrkoConfiguration config) {
+    ExchangeServiceImpl exchangeService = new ExchangeServiceImpl(config);
+    return exchangeService;
   }
 }

--- a/orko-common/src/test/java/com/gruelbox/orko/exchange/TestExchanges.java
+++ b/orko-common/src/test/java/com/gruelbox/orko/exchange/TestExchanges.java
@@ -31,11 +31,6 @@ import info.bitrich.xchangestream.coinbasepro.CoinbaseProStreamingExchange;
 public class TestExchanges {
 
   @Test
-  public void testGdaxSandbox() {
-    Assert.assertEquals(CoinbaseProStreamingExchange.class, Exchanges.friendlyNameToClass(Exchanges.GDAX_SANDBOX));
-  }
-
-  @Test
   public void testGdax() {
     Assert.assertEquals(CoinbaseProStreamingExchange.class, Exchanges.friendlyNameToClass(Exchanges.GDAX));
   }

--- a/orko-common/src/test/java/com/gruelbox/orko/marketdata/TestMarketDataIntegration.java
+++ b/orko-common/src/test/java/com/gruelbox/orko/marketdata/TestMarketDataIntegration.java
@@ -20,6 +20,7 @@ package com.gruelbox.orko.marketdata;
 
 import static com.gruelbox.orko.db.TestingUtils.skipIfSlowTestsDisabled;
 import static com.gruelbox.orko.exchange.Exchanges.BITMEX;
+import static com.gruelbox.orko.exchange.Exchanges.KUCOIN;
 import static com.gruelbox.orko.marketdata.MarketDataType.ORDERBOOK;
 import static com.gruelbox.orko.marketdata.MarketDataType.TICKER;
 import static com.gruelbox.orko.marketdata.MarketDataType.TRADES;
@@ -46,6 +47,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.gruelbox.orko.OrkoConfiguration;
 import com.gruelbox.orko.exchange.AccountServiceFactory;
+import com.gruelbox.orko.exchange.ExchangeConfiguration;
 import com.gruelbox.orko.exchange.ExchangeResource;
 import com.gruelbox.orko.exchange.ExchangeServiceImpl;
 import com.gruelbox.orko.exchange.Exchanges;
@@ -69,11 +71,11 @@ public class TestMarketDataIntegration {
   private static final TickerSpec gdax = TickerSpec.builder().base("BTC").counter("USD").exchange(Exchanges.GDAX).build();
   private static final TickerSpec bittrex = TickerSpec.builder().base("BTC").counter("USDT").exchange(Exchanges.BITTREX).build();
   //private static final TickerSpec cryptopia = TickerSpec.builder().base("BTC").counter("USDT").exchange(Exchanges.CRYPTOPIA).build();
-  private static final TickerSpec kucoin = TickerSpec.builder().base("BTC").counter("USDT").exchange(Exchanges.KUCOIN).build();
+  //private static final TickerSpec kucoin = TickerSpec.builder().base("BTC").counter("USDT").exchange(Exchanges.KUCOIN).build();
   private static final TickerSpec kraken = TickerSpec.builder().base("BTC").counter("USD").exchange(Exchanges.KRAKEN).build();
 
   private static final Set<MarketDataSubscription> subscriptions = FluentIterable.concat(
-      FluentIterable.of(binance, bitfinex, gdax, bittrex, kucoin, kraken)
+      FluentIterable.of(binance, bitfinex, gdax, bittrex, kraken)
         .transformAndConcat(spec -> ImmutableSet.of(
           MarketDataSubscription.create(spec, TICKER),
           MarketDataSubscription.create(spec, ORDERBOOK),
@@ -97,6 +99,11 @@ public class TestMarketDataIntegration {
     ((ch.qos.logback.classic.Logger)LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME)).setLevel(Level.INFO);
 
     OrkoConfiguration orkoConfiguration = new OrkoConfiguration();
+
+    // TODO temporary, to be resolved when Kucoin 2.0 is actually live
+    orkoConfiguration.setExchanges(ImmutableMap.of(KUCOIN, new ExchangeConfiguration()));
+    orkoConfiguration.getExchanges().get(KUCOIN).setSandbox(true);
+
     orkoConfiguration.setLoopSeconds(2);
     exchangeServiceImpl = new ExchangeServiceImpl(orkoConfiguration);
     marketDataSubscriptionManager = new MarketDataSubscriptionManager(

--- a/orko-ui/src/components/OpenOrders.js
+++ b/orko-ui/src/components/OpenOrders.js
@@ -197,7 +197,7 @@ const cancelColumn = (onCancelExchange, onCancelServer) => ({
           if (original.runningAt === "SERVER") {
             onCancelServer(original.jobId)
           } else {
-            onCancelExchange(original.id, original.type)
+            onCancelExchange(original.id)
           }
         }}
         title="Cancel order"

--- a/orko-ui/src/containers/OpenOrdersContainer.js
+++ b/orko-ui/src/containers/OpenOrdersContainer.js
@@ -26,8 +26,8 @@ import * as jobActions from "../store/job/actions"
 import { getOrdersForSelectedCoin } from "../selectors/coins"
 
 class OpenOrdersContainer extends React.Component {
-  onCancelExchange = (id, orderType, coin) => {
-    this.props.dispatch(exchangeActions.cancelOrder(coin, id, orderType))
+  onCancelExchange = (id, coin) => {
+    this.props.dispatch(exchangeActions.cancelOrder(coin, id))
   }
 
   onCancelServer = jobId => {
@@ -43,9 +43,7 @@ class OpenOrdersContainer extends React.Component {
               {() => (
                 <OpenOrders
                   orders={this.props.orders}
-                  onCancelExchange={(id, orderType) =>
-                    this.onCancelExchange(id, orderType, coin)
-                  }
+                  onCancelExchange={id => this.onCancelExchange(id, coin)}
                   onCancelServer={this.onCancelServer}
                   onWatch={this.onWatch}
                   coin={coin}

--- a/orko-ui/src/services/exchanges.js
+++ b/orko-ui/src/services/exchanges.js
@@ -102,7 +102,7 @@ class ExchangesService {
     )
   }
 
-  async cancelOrder(coin, id, orderType) {
+  async cancelOrder(coin, id) {
     return await del(
       "exchanges/" +
         coin.exchange +
@@ -111,9 +111,7 @@ class ExchangesService {
         "-" +
         coin.counter +
         "/orders/" +
-        id +
-        "?orderType=" +
-        orderType
+        id
     )
   }
 }

--- a/orko-ui/src/store/exchanges/actions.js
+++ b/orko-ui/src/store/exchanges/actions.js
@@ -77,7 +77,7 @@ export function submitStopOrder(exchange, order) {
   )
 }
 
-export function cancelOrder(coin, orderId, orderType) {
+export function cancelOrder(coin, orderId) {
   return async (dispatch, getState) => {
     dispatch(
       coinActions.orderUpdated(
@@ -91,7 +91,7 @@ export function cancelOrder(coin, orderId, orderType) {
     )
     dispatch(
       authActions.wrappedRequest(
-        () => exchangesService.cancelOrder(coin, orderId, orderType),
+        () => exchangesService.cancelOrder(coin, orderId),
         null,
         error =>
           errorActions.setForeground("Could not cancel order: " + error.message)

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
 
     <!--<xchange.groupid>org.knowm.xchange</xchange.groupid> -->
     <xchange.groupid>com.github.badgerwithagun.XChange</xchange.groupid>
-    <xchange.version>4.3.15.orko.2</xchange.version>
+    <xchange.version>orko-SNAPSHOT</xchange.version>
 
     <!--<xchange.stream.groupid>info.bitrich.xchange-stream</xchange.stream.groupid> -->
     <xchange.stream.groupid>com.github.badgerwithagun.xchange-stream</xchange.stream.groupid>


### PR DESCRIPTION
Add per-exchange configuration of whether sandbox should be used and remote metadata disabled. Bring in Kucoin 2.0.

Note that this only introduces public market data (ticker, order book, trades) support. I'm working on the private API at the moment.