### PR TITLE
Only use Jitpack if not available from OSSRH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,17 @@
 
   <repositories>
     <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
       <releases>
@@ -62,18 +73,7 @@
         <checksumPolicy>warn</checksumPolicy>
       </releases>
       <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>snapshots-repo</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
         <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
         <updatePolicy>always</updatePolicy>
       </snapshots>
     </repository>


### PR DESCRIPTION
Disable Jitpack for snapshots now everything is in Maven Central or at least OSSRH.

Thanks for your help!  Please make sure you've read the
[contributing guide](https://github.com/gruelbox/orko/wiki/Contributing) before submitting a pull request.
