### PR TITLE
Restore symmetry of password hashing

### DIFF
--- a/orko-app/src/main/java/com/gruelbox/orko/app/monolith/HashCommand.java
+++ b/orko-app/src/main/java/com/gruelbox/orko/app/monolith/HashCommand.java
@@ -38,7 +38,7 @@ class HashCommand extends Command {
     if (salt == null)
       salt = hasher.salt();
     System.out.println("Salt used: " + salt);
-    System.out.println("Hashed result: " + hasher.hashWithString(namespace.getString("value"), salt));
+    System.out.println("Hashed result: " + hasher.hash(namespace.getString("value"), salt));
   }
 
   @Override

--- a/orko-app/src/test/java/com/gruelbox/orko/app/monolith/TestCommandLine.java
+++ b/orko-app/src/test/java/com/gruelbox/orko/app/monolith/TestCommandLine.java
@@ -54,18 +54,18 @@ public class TestCommandLine {
 
   @Test
   public void testHashWithSaltLongArg() throws Exception {
-    String salt = captureStdOut(() -> MonolithApplication.main("salt")).substring(6);
-    String result = captureStdOut(() -> MonolithApplication.main("hash", "--salt", salt, "rhubarb"));
+    String salt = "bIR3DvCFPKLfY410OR2u5g==";
+    String result = captureStdOut(() -> MonolithApplication.main("hash", "--salt", salt, "porky pig the beast"));
     assertTrue(result.contains("Salt used: " + salt));
-    assertTrue(result.contains("Hashed result: HASH("));
+    assertTrue(result.contains("Hashed result: HASH(9NBwT2wpCuA2bCNw8d6JqRIVoxN+GOQzC4PgoH6I4j0=)"));
   }
 
   @Test
   public void testHashWithSaltShortArg() throws Exception {
-    String salt = captureStdOut(() -> MonolithApplication.main("salt")).substring(6);
-    String result = captureStdOut(() -> MonolithApplication.main("hash", "-s", salt, "rhubarb"));
+    String salt = "bIR3DvCFPKLfY410OR2u5g==";
+    String result = captureStdOut(() -> MonolithApplication.main("hash", "-s", salt, "porky pig the beast"));
     assertTrue(result.contains("Salt used: " + salt));
-    assertTrue(result.contains("Hashed result: HASH("));
+    assertTrue(result.contains("Hashed result: HASH(9NBwT2wpCuA2bCNw8d6JqRIVoxN+GOQzC4PgoH6I4j0=)"));
   }
 
   @Test

--- a/orko-auth/src/main/java/com/gruelbox/orko/auth/Hasher.java
+++ b/orko-auth/src/main/java/com/gruelbox/orko/auth/Hasher.java
@@ -53,8 +53,8 @@ public class Hasher {
   }
 
   public String hash(String value, String salt) {
-    Preconditions.checkNotNull(value);
-    Preconditions.checkNotNull(salt);
+    Preconditions.checkNotNull(value, "Null value cannot be hashed");
+    Preconditions.checkNotNull(salt, "Salt not supplied");
     KeySpec spec = new PBEKeySpec(value.toCharArray(), Base64.getDecoder().decode(salt), 65536, 256);
     try {
       SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");


### PR DESCRIPTION
The wrong algorithm was being used for the command line hasher, which didn't match the hashing performed on login.

Also added some error messages for when a salt isn't provided.