### PR TITLE
Add option to see orders of all coins in the order panel [WIP]

### DIFF
--- a/orko-ui/.gitignore
+++ b/orko-ui/.gitignore
@@ -21,3 +21,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 /target/
+
+.idea

--- a/orko-ui/package-lock.json
+++ b/orko-ui/package-lock.json
@@ -10043,8 +10043,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10081,8 +10080,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -10091,8 +10089,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10195,8 +10192,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10206,7 +10202,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10232,7 +10227,6 @@
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10249,7 +10243,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -10333,7 +10326,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10409,8 +10401,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10440,7 +10431,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10458,7 +10448,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10497,13 +10486,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -11969,7 +11956,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -11978,8 +11964,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -16913,6 +16898,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "prettier": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz",
+      "integrity": "sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.2.0",

--- a/orko-ui/package-lock.json
+++ b/orko-ui/package-lock.json
@@ -17853,6 +17853,11 @@
       "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.4.1.tgz",
       "integrity": "sha512-r6tLDyBP3U9cXNLEHs0n1mX5TQfmk6xE0Y9uinYZ5HOyAWDgIJxYqRRkU/bC6XrJ4nS7tasNbxaHJHVmf9UdkA=="
     },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+    },
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",

--- a/orko-ui/package.json
+++ b/orko-ui/package.json
@@ -54,6 +54,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "fomantic-ui": "^2.7.5",
     "gulp": "^4.0.2",
     "prettier": "1.17.1"
   }

--- a/orko-ui/package.json
+++ b/orko-ui/package.json
@@ -55,6 +55,6 @@
   ],
   "devDependencies": {
     "gulp": "^4.0.2",
-    "fomantic-ui": "^2.7.5"
+    "prettier": "1.17.1"
   }
 }

--- a/orko-ui/package.json
+++ b/orko-ui/package.json
@@ -26,6 +26,7 @@
     "reconnecting-websocket": "^4.1.10",
     "redux": "^4.0.1",
     "redux-batched-actions": "^0.4.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "seamless-immutable": "^7.1.4",

--- a/orko-ui/semantic.json
+++ b/orko-ui/semantic.json
@@ -19,5 +19,5 @@
   "autoInstall": false,
   "rtl": false,
   "components": ["reset", "site", "button", "container", "divider", "flag", "header", "icon", "image", "input", "label", "list", "loader", "placeholder", "rail", "reveal", "segment", "step", "breadcrumb", "form", "grid", "menu", "message", "table", "ad", "card", "comment", "feed", "item", "statistic", "accordion", "checkbox", "dimmer", "dropdown", "embed", "modal", "nag", "popup", "progress", "rating", "search", "shape", "sidebar", "sticky", "tab", "transition", "api", "form", "state", "visibility"],
-  "version": "2.7.2"
+  "version": "2.7.5"
 }

--- a/orko-ui/src/App.js
+++ b/orko-ui/src/App.js
@@ -22,7 +22,7 @@ import theme from "./theme"
 import { GlobalStyle } from "./theme"
 
 import { Provider as ReduxProvider } from "react-redux"
-import { compose, createStore, applyMiddleware } from "redux"
+import { createStore, applyMiddleware } from "redux"
 
 import createHistory from "history/createBrowserHistory"
 import { ConnectedRouter, routerMiddleware } from "connected-react-router"

--- a/orko-ui/src/App.js
+++ b/orko-ui/src/App.js
@@ -36,6 +36,7 @@ import * as socket from "./store/socket/connect"
 import ErrorContainer from "./containers/ErrorContainer"
 import AuthContainer from "./containers/AuthContainer"
 import FrameworkContainer from "./FrameworkContainer"
+import { composeWithDevTools } from "redux-devtools-extension"
 
 import * as authActions from "./store/auth/actions"
 
@@ -43,7 +44,7 @@ const history = createHistory()
 
 const store = createStore(
   enableBatching(createRootReducer(history)),
-  compose(
+  composeWithDevTools(
     applyMiddleware(routerMiddleware(history), thunk.withExtraArgument(socket))
   )
 )

--- a/orko-ui/src/components/OpenOrders.js
+++ b/orko-ui/src/components/OpenOrders.js
@@ -22,6 +22,7 @@ import Href from "../components/primitives/Href"
 import * as dateUtils from "../util/dateUtils"
 import Price from "../components/primitives/Price"
 import Amount from "../components/primitives/Amount"
+import { Link } from "react-router-dom"
 
 const textStyle = {
   textAlign: "left"
@@ -81,6 +82,46 @@ const runningAtColumn = {
   style: textStyle,
   resizable: true,
   width: 32
+}
+
+const exchangeColumn = {
+  id: "exchange",
+  Header: "Exchange",
+  accessor: "exchange",
+  Cell: ({ original }) => (
+    <Link
+      data-orko={original.coin.key + "/exchange"}
+      to={"/coin/" + original.coin.key}
+      title="Open coin"
+    >
+      {original.exchangeMeta
+        ? original.exchangeMeta.name
+        : original.coin.exchange}
+    </Link>
+  ),
+  headerStyle: textStyle,
+  style: textStyle,
+  resizable: true,
+  minWidth: 40
+}
+
+const nameColumn = {
+  id: "name",
+  Header: "Name",
+  accessor: "shortName",
+  Cell: ({ original }) => (
+    <Link
+      data-orko={original.coin.key + "/name"}
+      to={"/coin/" + original.coin.key}
+      title="Open coin"
+    >
+      {original.coin.shortName}
+    </Link>
+  ),
+  headerStyle: textStyle,
+  style: textStyle,
+  resizable: true,
+  minWidth: 50
 }
 
 const createdDateColumn = {
@@ -228,6 +269,8 @@ const OpenOrders = props => (
       cancelColumn(props.onCancelExchange, props.onCancelServer),
       orderTypeColumn,
       runningAtColumn,
+      exchangeColumn,
+      nameColumn,
       createdDateColumn,
       limitPriceColumn(props.coin),
       stopPriceColumn(props.coin),

--- a/orko-ui/src/containers/OpenOrdersContainer.js
+++ b/orko-ui/src/containers/OpenOrdersContainer.js
@@ -23,7 +23,7 @@ import WithCoin from "./WithCoin"
 import WhileLoading from "../components/WhileLoading"
 import * as exchangeActions from "../store/exchanges/actions"
 import * as jobActions from "../store/job/actions"
-import { getOrdersForSelectedCoin } from "../selectors/coins"
+import { getOrdersForAllCoin, getOrdersForSelectedCoin } from '../selectors/coins'
 
 class OpenOrdersContainer extends React.Component {
   onCancelExchange = (id, coin) => {
@@ -42,7 +42,7 @@ class OpenOrdersContainer extends React.Component {
             <WhileLoading data={this.props.orders} padded>
               {() => (
                 <OpenOrders
-                  orders={this.props.orders}
+                  orders={this.props.showAll? this.props.allOrders: this.props.orders}
                   onCancelExchange={id => this.onCancelExchange(id, coin)}
                   onCancelServer={this.onCancelServer}
                   onWatch={this.onWatch}
@@ -59,7 +59,8 @@ class OpenOrdersContainer extends React.Component {
 
 function mapStateToProps(state, props) {
   return {
-    orders: getOrdersForSelectedCoin(state)
+    orders: getOrdersForSelectedCoin(state),
+    allOrders: getOrdersForAllCoin(state)
   }
 }
 

--- a/orko-ui/src/containers/OpenOrdersContainer.js
+++ b/orko-ui/src/containers/OpenOrdersContainer.js
@@ -23,7 +23,10 @@ import WithCoin from "./WithCoin"
 import WhileLoading from "../components/WhileLoading"
 import * as exchangeActions from "../store/exchanges/actions"
 import * as jobActions from "../store/job/actions"
-import { getOrdersForAllCoin, getOrdersForSelectedCoin } from '../selectors/coins'
+import {
+  getOrdersForAllCoin,
+  getOrdersForSelectedCoin
+} from "../selectors/coins"
 
 class OpenOrdersContainer extends React.Component {
   onCancelExchange = (id, coin) => {
@@ -42,7 +45,11 @@ class OpenOrdersContainer extends React.Component {
             <WhileLoading data={this.props.orders} padded>
               {() => (
                 <OpenOrders
-                  orders={this.props.showAll? this.props.allOrders: this.props.orders}
+                  orders={
+                    this.props.showAll
+                      ? this.props.allOrders
+                      : this.props.orders
+                  }
                   onCancelExchange={id => this.onCancelExchange(id, coin)}
                   onCancelServer={this.onCancelServer}
                   onWatch={this.onWatch}

--- a/orko-ui/src/containers/OpenOrdersContainer.js
+++ b/orko-ui/src/containers/OpenOrdersContainer.js
@@ -45,11 +45,7 @@ class OpenOrdersContainer extends React.Component {
             <WhileLoading data={this.props.orders} padded>
               {() => (
                 <OpenOrders
-                  orders={
-                    this.props.showAll
-                      ? this.props.allOrders
-                      : this.props.orders
-                  }
+                  orders={this.props.orders}
                   onCancelExchange={id => this.onCancelExchange(id, coin)}
                   onCancelServer={this.onCancelServer}
                   onWatch={this.onWatch}
@@ -66,8 +62,9 @@ class OpenOrdersContainer extends React.Component {
 
 function mapStateToProps(state, props) {
   return {
-    orders: getOrdersForSelectedCoin(state),
-    allOrders: getOrdersForAllCoin(state)
+    orders: this.props.showAll
+      ? getOrdersForAllCoin(state)
+      : getOrdersForSelectedCoin(state)
   }
 }
 

--- a/orko-ui/src/containers/OpenOrdersContainer.js
+++ b/orko-ui/src/containers/OpenOrdersContainer.js
@@ -62,7 +62,7 @@ class OpenOrdersContainer extends React.Component {
 
 function mapStateToProps(state, props) {
   return {
-    orders: this.props.showAll
+    orders: props.showAll
       ? getOrdersForAllCoin(state)
       : getOrdersForSelectedCoin(state)
   }

--- a/orko-ui/src/containers/OrdersContainer.js
+++ b/orko-ui/src/containers/OrdersContainer.js
@@ -15,40 +15,61 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React from "react"
-import Section from "../components/primitives/Section"
-import Tab from "../components/primitives/Tab"
-import OpenOrdersContainer from "./OpenOrdersContainer"
-import UserTradeHistoryContainer from "./UserTradeHistoryContainer"
-import GetPageVisibility from "../components/GetPageVisibility"
-import RenderIf from "../components/RenderIf"
+import React from 'react'
+import Section from '../components/primitives/Section'
+import Tab from '../components/primitives/Tab'
+import OpenOrdersContainer from './OpenOrdersContainer'
+import UserTradeHistoryContainer from './UserTradeHistoryContainer'
+import GetPageVisibility from '../components/GetPageVisibility'
+import RenderIf from '../components/RenderIf'
+import { Checkbox } from 'semantic-ui-react'
+import { getValueFromLS, saveValueToLS } from '../util/localStorage'
+
+const ORDER_STORAGE_KEY = 'OrdersContainer.order_show_all'
 
 class OrdersContainer extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
-    this.state = { selected: "open" }
+    var showAll = getValueFromLS(ORDER_STORAGE_KEY) !== 'false'
+    if (showAll === null) showAll = false
+    this.state = {
+      selected: 'open',
+      showAll
+    }
   }
 
   buttons = () => (
     <span>
+    <Tab
+      selected={this.state.showAll}
+      onClick={() => {
+        this.setState(
+          prev => ({showAll: !prev.showAll}),
+          () => saveValueToLS(ORDER_STORAGE_KEY, this.state.showAll)
+        )
+      }}
+      title="Show orders for all coins or selected coins"
+      >
+        Show All
+      </Tab>
       <Tab
-        selected={this.state.selected === "open"}
-        onClick={() => this.setState({ selected: "open" })}
-        title="Show open orders for the selected coin"
+        selected={this.state.selected === 'open'}
+        onClick={() => this.setState({selected: 'open'})}
+        title={this.state.showAll ? 'Show open orders for all coin' : 'Show open orders for the selected coin'}
       >
         Open
       </Tab>
       <Tab
-        selected={this.state.selected === "history"}
-        onClick={() => this.setState({ selected: "history" })}
-        title="Show order history for the selected coin"
+        selected={this.state.selected === 'history'}
+        onClick={() => this.setState({selected: 'history'})}
+        title={this.state.showAll ? 'Show order history for all coin' : 'Show order history for the selected coin'}
       >
         History
       </Tab>
     </span>
   )
 
-  render() {
+  render () {
     return (
       <GetPageVisibility>
         {visible => (
@@ -59,10 +80,10 @@ class OrdersContainer extends React.Component {
               heading="Orders"
               buttons={this.buttons}
             >
-              {this.state.selected === "open" ? (
-                <OpenOrdersContainer />
+              {this.state.selected === 'open' ? (
+                <OpenOrdersContainer showAll={this.state.showAll}/>
               ) : (
-                <UserTradeHistoryContainer />
+                <UserTradeHistoryContainer showAll={this.state.showAll}/>
               )}
             </Section>
           </RenderIf>

--- a/orko-ui/src/containers/OrdersContainer.js
+++ b/orko-ui/src/containers/OrdersContainer.js
@@ -15,60 +15,68 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react'
-import Section from '../components/primitives/Section'
-import Tab from '../components/primitives/Tab'
-import OpenOrdersContainer from './OpenOrdersContainer'
-import UserTradeHistoryContainer from './UserTradeHistoryContainer'
-import GetPageVisibility from '../components/GetPageVisibility'
-import RenderIf from '../components/RenderIf'
-import { getValueFromLS, saveValueToLS } from '../util/localStorage'
+import React from "react"
+import Section from "../components/primitives/Section"
+import Tab from "../components/primitives/Tab"
+import OpenOrdersContainer from "./OpenOrdersContainer"
+import UserTradeHistoryContainer from "./UserTradeHistoryContainer"
+import GetPageVisibility from "../components/GetPageVisibility"
+import RenderIf from "../components/RenderIf"
+import { getValueFromLS, saveValueToLS } from "../util/localStorage"
 
-const ORDER_STORAGE_KEY = 'OrdersContainer.order_show_all'
+const ORDER_STORAGE_KEY = "OrdersContainer.order_show_all"
 
 class OrdersContainer extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
-    var showAll = getValueFromLS(ORDER_STORAGE_KEY) !== 'false'
+    var showAll = getValueFromLS(ORDER_STORAGE_KEY) !== "false"
     if (showAll === null) showAll = false
     this.state = {
-      selected: 'open',
+      selected: "open",
       showAll
     }
   }
 
   buttons = () => (
     <span>
-    <Tab
-      selected={this.state.showAll}
-      onClick={() => {
-        this.setState(
-          prev => ({showAll: !prev.showAll}),
-          () => saveValueToLS(ORDER_STORAGE_KEY, this.state.showAll)
-        )
-      }}
-      title="Show orders for all coins or selected coins"
+      <Tab
+        selected={this.state.showAll}
+        onClick={() => {
+          this.setState(
+            prev => ({ showAll: !prev.showAll }),
+            () => saveValueToLS(ORDER_STORAGE_KEY, this.state.showAll)
+          )
+        }}
+        title="Show orders for all coins or selected coins"
       >
         Show All
       </Tab>
       <Tab
-        selected={this.state.selected === 'open'}
-        onClick={() => this.setState({selected: 'open'})}
-        title={this.state.showAll ? 'Show open orders for all coin' : 'Show open orders for the selected coin'}
+        selected={this.state.selected === "open"}
+        onClick={() => this.setState({ selected: "open" })}
+        title={
+          this.state.showAll
+            ? "Show open orders for all coin"
+            : "Show open orders for the selected coin"
+        }
       >
         Open
       </Tab>
       <Tab
-        selected={this.state.selected === 'history'}
-        onClick={() => this.setState({selected: 'history'})}
-        title={this.state.showAll ? 'Show order history for all coin' : 'Show order history for the selected coin'}
+        selected={this.state.selected === "history"}
+        onClick={() => this.setState({ selected: "history" })}
+        title={
+          this.state.showAll
+            ? "Show order history for all coin"
+            : "Show order history for the selected coin"
+        }
       >
         History
       </Tab>
     </span>
   )
 
-  render () {
+  render() {
     return (
       <GetPageVisibility>
         {visible => (
@@ -79,10 +87,10 @@ class OrdersContainer extends React.Component {
               heading="Orders"
               buttons={this.buttons}
             >
-              {this.state.selected === 'open' ? (
-                <OpenOrdersContainer showAll={this.state.showAll}/>
+              {this.state.selected === "open" ? (
+                <OpenOrdersContainer showAll={this.state.showAll} />
               ) : (
-                <UserTradeHistoryContainer showAll={this.state.showAll}/>
+                <UserTradeHistoryContainer showAll={this.state.showAll} />
               )}
             </Section>
           </RenderIf>

--- a/orko-ui/src/containers/OrdersContainer.js
+++ b/orko-ui/src/containers/OrdersContainer.js
@@ -22,7 +22,6 @@ import OpenOrdersContainer from './OpenOrdersContainer'
 import UserTradeHistoryContainer from './UserTradeHistoryContainer'
 import GetPageVisibility from '../components/GetPageVisibility'
 import RenderIf from '../components/RenderIf'
-import { Checkbox } from 'semantic-ui-react'
 import { getValueFromLS, saveValueToLS } from '../util/localStorage'
 
 const ORDER_STORAGE_KEY = 'OrdersContainer.order_show_all'

--- a/orko-ui/src/selectors/coins.js
+++ b/orko-ui/src/selectors/coins.js
@@ -65,6 +65,30 @@ function jobTriggerMatchesCoin(job, coin) {
   )
 }
 
+function serverJobDecorate(job) {
+  return {
+    runningAt: "SERVER",
+    jobId: job.id,
+    type: job.high
+      ? job.high.job.direction === "BUY"
+        ? "BID"
+        : "ASK"
+      : job.low.job.direction === "BUY"
+        ? "BID"
+        : "ASK",
+    stopPrice: job.high
+      ? Number(job.high.thresholdAsString)
+      : Number(job.low.thresholdAsString),
+    limitPrice: job.high
+      ? Number(job.high.job.limitPrice)
+      : Number(job.low.job.limitPrice),
+    originalAmount: job.high
+      ? Number(job.high.job.amount)
+      : Number(job.low.job.amount),
+    cumulativeAmount: "--"
+  }
+}
+
 export const getOrdersForSelectedCoin = createSelector(
   [getOrders, getStopJobs, getSelectedCoin],
   (orders, stopJobs, selectedCoin) => {
@@ -74,27 +98,23 @@ export const getOrdersForSelectedCoin = createSelector(
 
     const server = stopJobs
       .filter(job => jobTriggerMatchesCoin(job, selectedCoin))
-      .map(job => ({
-        runningAt: "SERVER",
-        jobId: job.id,
-        type: job.high
-          ? job.high.job.direction === "BUY"
-            ? "BID"
-            : "ASK"
-          : job.low.job.direction === "BUY"
-          ? "BID"
-          : "ASK",
-        stopPrice: job.high
-          ? Number(job.high.thresholdAsString)
-          : Number(job.low.thresholdAsString),
-        limitPrice: job.high
-          ? Number(job.high.job.limitPrice)
-          : Number(job.low.job.limitPrice),
-        originalAmount: job.high
-          ? Number(job.high.job.amount)
-          : Number(job.low.job.amount),
-        cumulativeAmount: "--"
-      }))
+      .map(job => serverJobDecorate(job))
+
+    result = result.concat(server)
+
+    if (result.length === 0 && !orders) return null
+
+    return result
+  }
+)
+
+export const getOrdersForAllCoin = createSelector(
+  [getOrders, getStopJobs],
+  (orders, stopJobs) => {
+    var result = !orders ? [] : orders.filter(o => !o.deleted)
+
+    const server = stopJobs
+      .map(job => serverJobDecorate(job))
 
     result = result.concat(server)
 

--- a/orko-ui/src/selectors/coins.js
+++ b/orko-ui/src/selectors/coins.js
@@ -74,8 +74,8 @@ function serverJobDecorate(job) {
         ? "BID"
         : "ASK"
       : job.low.job.direction === "BUY"
-        ? "BID"
-        : "ASK",
+      ? "BID"
+      : "ASK",
     stopPrice: job.high
       ? Number(job.high.thresholdAsString)
       : Number(job.low.thresholdAsString),
@@ -113,8 +113,7 @@ export const getOrdersForAllCoin = createSelector(
   (orders, stopJobs) => {
     var result = !orders ? [] : orders.filter(o => !o.deleted)
 
-    const server = stopJobs
-      .map(job => serverJobDecorate(job))
+    const server = stopJobs.map(job => serverJobDecorate(job))
 
     result = result.concat(server)
 

--- a/orko-ui/src/store/coin/actions.js
+++ b/orko-ui/src/store/coin/actions.js
@@ -45,8 +45,8 @@ export function clearBalances() {
   return { type: types.CLEAR_BALANCES }
 }
 
-export function orderUpdated(order, timestamp) {
-  return { type: types.ORDER_UPDATED, payload: { order, timestamp } }
+export function orderUpdated(coin, order, timestamp) {
+  return { type: types.ORDER_UPDATED, payload: { coin, order, timestamp } }
 }
 
 export function clearOrders() {

--- a/orko-ui/src/worker/socket.client.js
+++ b/orko-ui/src/worker/socket.client.js
@@ -152,7 +152,7 @@ export function resubscribe() {
   })
   send({
     command: socketMessages.CHANGE_OPEN_ORDERS,
-    tickers: serverSelectedCoinTickers
+    tickers: subscribedCoins.map(coin => webCoinToServerCoin(coin))
   })
   send({
     command: socketMessages.CHANGE_ORDER_BOOK,
@@ -164,7 +164,7 @@ export function resubscribe() {
   })
   send({
     command: socketMessages.CHANGE_ORDER_STATUS_CHANGE,
-    tickers: serverSelectedCoinTickers
+    tickers: subscribedCoins.map(coin => webCoinToServerCoin(coin))
   })
   send({
     command: socketMessages.CHANGE_USER_TRADES,


### PR DESCRIPTION
This pr resolve #373.
Add a tab in the orders panel to toggle options for showing orders for all coins.